### PR TITLE
Version 0.4.0 of moment-timezone + version 2.8.3 of momentjs + fixing missing paths and shims

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,23 +11,27 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>moment-timezone</artifactId>
-    <version>0.3.1-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
     <name>Moment.js Timezone plugin</name>
     <description>WebJar for Moment.js Timezone</description>
     <url>http://webjars.org</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>0.3.0</upstream.version>
+        <upstream.version>0.4.0</upstream.version>
         <upstream.url>https://github.com/moment/moment-timezone/archive/${upstream.version}.zip</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${project.version}</destDir>
         <requirejs>
             {
                 "paths": {
-                    "moment-timezone": "moment-timezone"
+                    "moment-timezone": "moment-timezone",
+                    "moment-timezone-with-data": "moment-timezone-with-data",
+                    "moment-timezone-with-data-2010-2020": "moment-timezone-with-data-2010-2020"
                 },
                 "shim": {
-                    "moment-timezone": ["momentjs"]
+                    "moment-timezone": ["momentjs"],
+                    "moment-timezone-with-data": ["momentjs"],
+                    "moment-timezone-with-data-2010-2020": ["momentjs"]
                 }
             }
         </requirejs>
@@ -60,7 +64,7 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>momentjs</artifactId>
-            <version>2.8.2</version>
+            <version>2.8.3</version>
         </dependency>
     </dependencies>
     


### PR DESCRIPTION
- bump `moment-timezone` to latest version `0.4.0`
- bump `momentjs` to version `2.8.3`
- extend requirejs configuration `paths` to allow using `moment-timezone-with-data` and `moment-timezone-with-data-2010-2020`
- extend requirejs configuration `shims` to declare dependency to `momentjs` for `moment-timezone-with-data` and `moment-timezone-with-data-2010-2020`

The momentjs timezone plugin needs some timezone data to function. You can either load just the data you need (`moment-timezone`) or use a build of the plugin with some (`moment-timezone-with-data-2010-2020`) or all the data included (`moment-timezone-with-data`).

From the momentjs timezone docs:

> To use moment-timezone, you will need moment@2.6.0+, moment-timezone.js, and the moment-timezone data.
> For convenience, there are builds available on momentjs.com/timezone/ with all the zone data or a subset of the data with support for only 2010-2020.
